### PR TITLE
Improve wantToRead function

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -49,6 +49,14 @@ export class UsersController {
     return this.usersService.findOne(id);
   }
 
+  @Get('want-to-read/:bookId')
+  async getWantToReadStatus(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('bookId') bookId: string,
+  ) {
+    return this.usersService.getWantToReadStatus(user.userId, bookId);
+  }
+
   @Patch('want-to-read/:bookId')
   async updateWantToRead(
     @CurrentUser() user: AuthenticatedUser,

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -114,6 +114,34 @@ export class UsersService {
     return updatedUser;
   }
 
+  async getWantToReadStatus(
+    userId: string,
+    bookId: string,
+  ): Promise<{ bookId: string; wantToRead: boolean }> {
+    const sanitizedBookId = bookId.trim();
+
+    if (!sanitizedBookId) {
+      throw new BadRequestException('Book ID cannot be empty');
+    }
+
+    const user = await this.userModel
+      .findById(userId, {
+        books: { $elemMatch: { bookId: sanitizedBookId } },
+      })
+      .exec();
+
+    if (!user) {
+      throw new NotFoundException(`User with ID ${userId} not found`);
+    }
+
+    const entry = Array.isArray(user.books) ? user.books[0] : undefined;
+
+    return {
+      bookId: sanitizedBookId,
+      wantToRead: Boolean(entry?.wantToRead),
+    };
+  }
+
   async remove(id: string): Promise<void> {
     const result = await this.userModel.findByIdAndDelete(id).exec();
     if (!result) {


### PR DESCRIPTION
Hicimos que los usuarios puedan marcar un libro como “quiero leerlo” y que eso se guarde.
Así, cuando el usuario vuelve a la ficha del libro, simplemente llamamos al GET y sabemos si debe aparecer marcado.

- Añadimos al usuario un array books con { bookId, wantToRead }, evitando duplicados.
- Creamos un PATCH PATCH /users/want-to-read/:bookId que marca o desmarca el libro, pidiendo en el body { "wantToRead": true | false }.
- Añadimos un GET /users/want-to-read/:bookId para que el front pregunte si ese libro ya está marcado y así pintar el toggle correcto.
- Internamente, usamos los operadores de Mongo $pull y $push para añadir/quitar el libro en un solo viaje.
